### PR TITLE
Add GHCR publishing to Docker workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -26,34 +26,45 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
+        uses: docker/login-action@v3
         with:
           # registry: ${{ env.REGISTRY }}
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
+      - name: Login to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       # Extract metadata (tags, labels) for Docker
       # https://github.com/docker/metadata-action
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        uses: docker/metadata-action@v5
         with:
-          images: ronnieroller/media-roller
-          tag-sha: true
-          tag-latest: true
+          images: |
+            docker.io/ronnieroller/media-roller
+            ghcr.io/ronnieroller/media-roller
+          tags: |
+            type=ref,event=branch,branch=master,latest=true
+            type=sha
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ronnieroller/media-roller:latest
+          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
DockerHub is changing their pull rate limits on March 10th, reducing unauthenticated pulls to just 10 per hour (down from 100 every 6 hours). This will impact users, particularly those bootstrapping clusters.
ref: https://docs.docker.com/docker-hub/usage/

To mitigate these new limits, this PR updates the workflow to push images to both DockerHub and GitHub Container Registry (GHCR). GHCR uses the automatically generated GITHUB_TOKEN, so no additional configuration or secrets are required on your end. GHCR is also completely free for open source projects like this -- which I am very grateful for btw. 

Thanks for looking at this!

I also did bump some version for the workflow. 